### PR TITLE
Make it compatible with Ruby 3

### DIFF
--- a/lib/gtfs_reader/file_reader.rb
+++ b/lib/gtfs_reader/file_reader.rb
@@ -20,7 +20,7 @@ module GtfsReader
     def initialize(data, definition, opts = {})
       opts = { parse: true, validate: false, hash: true }.merge(opts)
 
-      @csv = CSV.new(data, CSV_OPTIONS)
+      @csv = CSV.new(data, **CSV_OPTIONS)
       @definition = definition
       @do_parse = opts[:parse]
       @return_hash = opts[:hash]


### PR DESCRIPTION
Hi! Found this problem when bumping my project to Ruby 3(.1.2); since the fix is trivial and backwards-compatible, I decided to report and PR the fix here. Thanks! 🙇 

### The issue

When running the reader in Ruby 3, we get:

```
ArgumentError: wrong number of arguments (given 4, expected 1)
/home/codespace/.rbenv/versions/3.1.2/lib/ruby/3.1.0/csv.rb:1744:in `initialize'
/home/codespace/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/gtfs_reader-4.1.0/lib/gtfs_reader/file_reader.rb:23:in `new'
```

### Steps to reproduce

1) Change your environment to Ruby 3, e.g.:

```bash
rbenv install 3.1.2
rbenv rehash
bundle install
```

2) Run the specs (`bundle exec rspec`)

### Expected result

No errors

### Actual result

<details>
<summary>RSpec output (click to expand)</summary>

```
$ rspec
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 61187
................................................................FFFFFFF..........

Failures:

  1) GtfsReader::FileReader columns 
     Failure/Error: @csv = CSV.new(data, CSV_OPTIONS)
     
     ArgumentError:
       wrong number of arguments (given 2, expected 1)
     # ./lib/gtfs_reader/file_reader.rb:23:in `new'
     # ./lib/gtfs_reader/file_reader.rb:23:in `initialize'
     # ./spec/gtfs-reader/file_reader_spec.rb:39:in `new'
     # ./spec/gtfs-reader/file_reader_spec.rb:39:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:52:in `its'
     # ./spec/gtfs-reader/file_reader_spec.rb:41:in `block (3 levels) in <top (required)>'

  2) GtfsReader::FileReader columns 
     Failure/Error: @csv = CSV.new(data, CSV_OPTIONS)
     
     ArgumentError:
       wrong number of arguments (given 2, expected 1)
     # ./lib/gtfs_reader/file_reader.rb:23:in `new'
     # ./lib/gtfs_reader/file_reader.rb:23:in `initialize'
     # ./spec/gtfs-reader/file_reader_spec.rb:39:in `new'
     # ./spec/gtfs-reader/file_reader_spec.rb:39:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:52:in `its'
     # ./spec/gtfs-reader/file_reader_spec.rb:40:in `block (3 levels) in <top (required)>'

  3) GtfsReader::FileReader parsing 
     Failure/Error: @csv = CSV.new(data, CSV_OPTIONS)
     
     ArgumentError:
       wrong number of arguments (given 2, expected 1)
     # ./lib/gtfs_reader/file_reader.rb:23:in `new'
     # ./lib/gtfs_reader/file_reader.rb:23:in `initialize'
     # ./spec/gtfs-reader/file_reader_spec.rb:45:in `new'
     # ./spec/gtfs-reader/file_reader_spec.rb:45:in `block (3 levels) in <top (required)>'
     # ./spec/gtfs-reader/file_reader_spec.rb:56:in `block (3 levels) in <top (required)>'

  4) GtfsReader::FileReader parsing with no rows 
     Failure/Error: @csv = CSV.new(data, CSV_OPTIONS)
     
     ArgumentError:
       wrong number of arguments (given 2, expected 1)
     # ./lib/gtfs_reader/file_reader.rb:23:in `new'
     # ./lib/gtfs_reader/file_reader.rb:23:in `initialize'
     # ./spec/gtfs-reader/file_reader_spec.rb:45:in `new'
     # ./spec/gtfs-reader/file_reader_spec.rb:45:in `block (3 levels) in <top (required)>'
     # ./spec/gtfs-reader/file_reader_spec.rb:77:in `block (4 levels) in <top (required)>'

  5) GtfsReader::FileReader parsing parser with column reference 
     Failure/Error: @csv = CSV.new(data, CSV_OPTIONS)
     
     ArgumentError:
       wrong number of arguments (given 2, expected 1)
     # ./lib/gtfs_reader/file_reader.rb:23:in `new'
     # ./lib/gtfs_reader/file_reader.rb:23:in `initialize'
     # ./spec/gtfs-reader/file_reader_spec.rb:45:in `new'
     # ./spec/gtfs-reader/file_reader_spec.rb:45:in `block (3 levels) in <top (required)>'
     # ./spec/gtfs-reader/file_reader_spec.rb:71:in `block (4 levels) in <top (required)>'

  6) GtfsReader::FileReader parsing with one row 
     Failure/Error: @csv = CSV.new(data, CSV_OPTIONS)
     
     ArgumentError:
       wrong number of arguments (given 2, expected 1)
     # ./lib/gtfs_reader/file_reader.rb:23:in `new'
     # ./lib/gtfs_reader/file_reader.rb:23:in `initialize'
     # ./spec/gtfs-reader/file_reader_spec.rb:45:in `new'
     # ./spec/gtfs-reader/file_reader_spec.rb:45:in `block (3 levels) in <top (required)>'
     # ./spec/gtfs-reader/file_reader_spec.rb:83:in `block (4 levels) in <top (required)>'

  7) GtfsReader::FileReader new with a required column with bad data is expected to raise GtfsReader::RequiredColumnsMissing
     Failure/Error:
       expect { subject.new data, definition, validate: true }
         .to raise_exception GtfsReader::RequiredColumnsMissing
     
       expected GtfsReader::RequiredColumnsMissing, got #<ArgumentError: wrong number of arguments (given 2, expected 1)> with backtrace:
         # ./lib/gtfs_reader/file_reader.rb:23:in `new'
         # ./lib/gtfs_reader/file_reader.rb:23:in `initialize'
         # ./spec/gtfs-reader/file_reader_spec.rb:31:in `new'
         # ./spec/gtfs-reader/file_reader_spec.rb:31:in `block (6 levels) in <top (required)>'
         # ./spec/gtfs-reader/file_reader_spec.rb:31:in `block (5 levels) in <top (required)>'
     # ./spec/gtfs-reader/file_reader_spec.rb:31:in `block (5 levels) in <top (required)>'

Top 5 slowest examples (0.07943 seconds, 47.8% of total time):
  4.1.0 is expected to satisfy expression `[String, NilClass].include?(klass)`
    0.02323 seconds ./spec/gtfs-reader/version_spec.rb:8
  GtfsReader::Config::Sources is expected to change `subject[:city]` from nil to be a kind of GtfsReader::Config::Source
    0.01917 seconds ./spec/gtfs-reader/config/sources_spec.rb:4
  GtfsReader::FileReader new with a required column with bad data is expected to raise GtfsReader::RequiredColumnsMissing
    0.01446 seconds ./spec/gtfs-reader/file_reader_spec.rb:30
  GtfsReader::Config is expected to change `definition.required_columns.collect(&:name)` to eq [:a, :b]
    0.01257 seconds ./spec/gtfs-reader/config/file_definition_spec.rb:29
  GtfsReader::Log level is expected to change `its :level`
    0.01 seconds ./spec/gtfs-reader/log_spec.rb:34

Top 5 slowest example groups:
  GtfsReader::Config::Sources
    0.0194 seconds average (0.0194 seconds / 1 example) ./spec/gtfs-reader/config/sources_spec.rb:1
  4.1.0
    0.00513 seconds average (0.02566 seconds / 5 examples) ./spec/gtfs-reader/version_spec.rb:3
  GtfsReader::FeedHandler
    0.00254 seconds average (0.00254 seconds / 1 example) ./spec/gtfs-reader/feed_handler_spec.rb:1
  GtfsReader::FileReader
    0.00249 seconds average (0.01741 seconds / 7 examples) ./spec/gtfs-reader/file_reader_spec.rb:3
  GtfsReader::Log
    0.00215 seconds average (0.02362 seconds / 11 examples) ./spec/gtfs-reader/log_spec.rb:1

Finished in 0.16611 seconds (files took 0.44336 seconds to load)
81 examples, 7 failures

Failed examples:

rspec ./spec/gtfs-reader/file_reader_spec.rb:41 # GtfsReader::FileReader columns 
rspec ./spec/gtfs-reader/file_reader_spec.rb:40 # GtfsReader::FileReader columns 
rspec ./spec/gtfs-reader/file_reader_spec.rb:56 # GtfsReader::FileReader parsing 
rspec ./spec/gtfs-reader/file_reader_spec.rb:77 # GtfsReader::FileReader parsing with no rows 
rspec ./spec/gtfs-reader/file_reader_spec.rb:71 # GtfsReader::FileReader parsing parser with column reference 
rspec ./spec/gtfs-reader/file_reader_spec.rb:83 # GtfsReader::FileReader parsing with one row 
rspec ./spec/gtfs-reader/file_reader_spec.rb:30 # GtfsReader::FileReader new with a required column with bad data is expected to raise GtfsReader::RequiredColumnsMissing

Randomized with seed 61187

Coverage report generated for RSpec to /workspaces/gtfs_reader/coverage. 795 / 995 LOC (79.9%) covered.
Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
```
</details>

### Cause

`GtfsReader::FileReader` initializes `CSV` using automatic conversion of hash parameters, which was [removed in Ruby 3](
 https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)

### Fix

Just added `**` to expand the hash into parameters. It causes rspec and my import to succeed, and is backwards-compatible with Ruby 2